### PR TITLE
Remove shell prompt form shell examples to be copy-pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here are example ways to run it using [Docker CLI](#docker-cli), [Docker Compose
 
 1. Start a server where you want to copy data **from**:
 ```sh
-$ docker run --rm -e NGROK_AUTHTOKEN="$NGROK_AUTHTOKEN" \
+docker run --rm -e NGROK_AUTHTOKEN="$NGROK_AUTHTOKEN" \
   --mount source=MY_SOURCE_VOLUME,target=/data,readonly \
   quay.io/suda/dvsync-server
 ```
@@ -36,7 +36,7 @@ $ docker run --rm -e NGROK_AUTHTOKEN="$NGROK_AUTHTOKEN" \
 2. Once the server started, look into the logs and copy the `DVSYNC_TOKEN`
 3. Start the client where you want tot copy the data **to**:
 ```sh
-$ docker run --rm -e DVSYNC_TOKEN="$DVSYNC_TOKEN" \
+docker run --rm -e DVSYNC_TOKEN="$DVSYNC_TOKEN" \
   --mount source=MY_TARGET_VOLUME,target=/data \
   quay.io/suda/dvsync-client
 ```
@@ -45,7 +45,7 @@ $ docker run --rm -e DVSYNC_TOKEN="$DVSYNC_TOKEN" \
 Alternatively, if you want to copy this data to your local machine, you can mount a host directory as well:
 
 ```sh
-$ docker run --rm -e DVSYNC_TOKEN="$DVSYNC_TOKEN" \
+docker run --rm -e DVSYNC_TOKEN="$DVSYNC_TOKEN" \
   -v $PWD:/data \
   quay.io/suda/dvsync-client
 ```


### PR DESCRIPTION
Useful especially after GitHub added "Copy" widget.